### PR TITLE
task-4548: Test Pack configurator now supports Reports Test Pack generation

### DIFF
--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreator.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreator.java
@@ -3,6 +3,7 @@ package com.regnosys.testing.testpack;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.ImplementedBy;
+import com.google.inject.Injector;
 
 import java.util.List;
 
@@ -12,9 +13,15 @@ public interface TestPackConfigCreator {
     /**
      * Generates pipeline and test-pack config files.
      *
-     * @param rosettaPaths - list of folders that contain rosetta model files, e.g. "drr/rosetta"
-     * @param filter       - provides filters to include or exclude
-     * @param testPackDefs - provides list of test-pack information such as test pack name, input type and sample input paths
+     * @param rosettaPaths      - list of folders that contain rosetta model files, e.g. "drr/rosetta"
+     * @param filter            - provides filters to include or exclude
+     * @param testPackDefs      - provides list of test-pack information such as test pack name, input type and sample input paths
+     * @param functionSchemaMap - function / xsd look up map
+     * @param injector          - model runtime guice injector
      */
-    void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths, TestPackFilter filter, List<TestPackDef> testPackDefs, ImmutableMap<String, String> functionSchemaMap);
+    void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths, 
+                                         TestPackFilter filter, 
+                                         List<TestPackDef> testPackDefs, 
+                                         ImmutableMap<Class<?>, String> functionSchemaMap, 
+                                         Injector injector);
 }

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreator.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreator.java
@@ -1,6 +1,7 @@
 package com.regnosys.testing.testpack;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.ImplementedBy;
 
 import java.util.List;
@@ -15,5 +16,5 @@ public interface TestPackConfigCreator {
      * @param filter       - provides filters to include or exclude
      * @param testPackDefs - provides list of test-pack information such as test pack name, input type and sample input paths
      */
-    void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths, TestPackFilter filter, List<TestPackDef> testPackDefs);
+    void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths, TestPackFilter filter, List<TestPackDef> testPackDefs, ImmutableMap<String, String> functionSchemaMap);
 }

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreator.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreator.java
@@ -13,15 +13,15 @@ public interface TestPackConfigCreator {
     /**
      * Generates pipeline and test-pack config files.
      *
-     * @param rosettaPaths      - list of folders that contain rosetta model files, e.g. "drr/rosetta"
-     * @param filter            - provides filters to include or exclude
-     * @param testPackDefs      - provides list of test-pack information such as test pack name, input type and sample input paths
-     * @param functionSchemaMap - function / xsd look up map
-     * @param injector          - model runtime guice injector
+     * @param rosettaPaths    - list of folders that contain rosetta model files, e.g. "drr/rosetta"
+     * @param filter          - provides filters to include or exclude
+     * @param testPackDefs    - provides list of test-pack information such as test pack name, input type and sample input paths
+     * @param outputSchemaMap - output Document type / xsd look up map
+     * @param injector        - model runtime guice injector
      */
-    void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths, 
-                                         TestPackFilter filter, 
-                                         List<TestPackDef> testPackDefs, 
-                                         ImmutableMap<Class<?>, String> functionSchemaMap, 
+    void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths,
+                                         TestPackFilter filter,
+                                         List<TestPackDef> testPackDefs,
+                                         ImmutableMap<Class<?>, String> outputSchemaMap,
                                          Injector injector);
 }

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -54,14 +54,14 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
      * @param rosettaPaths      - list of folders that contain rosetta model files, e.g. "drr/rosetta"
      * @param filter            - provides filters to include or exclude
      * @param testPackDefs      - provides list of test-pack information such as test pack name, input type and sample input paths
-     * @param functionSchemaMap - function / xsd look up map
+     * @param outputSchemaMap - function / xsd look up map
      * @param injector          - model runtime guice injector
      */
     @Override
     public void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths,
                                                 TestPackFilter filter,
                                                 List<TestPackDef> testPackDefs,
-                                                ImmutableMap<Class<?>, String> functionSchemaMap,
+                                                ImmutableMap<Class<?>, String> outputSchemaMap,
                                                 Injector injector) {
         if (TEST_WRITE_BASE_PATH.isEmpty()) {
             LOGGER.error("TEST_WRITE_BASE_PATH not set");
@@ -93,7 +93,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
         projectionPipelines.forEach(p -> testPackConfigWriter.writeConfigFile(writePath, PROJECTION_CONFIG_PATH, p.getId(), p));
 
         LOGGER.info("Projection test pack config");
-        List<TestPackModel> projectionTestPacks = createProjectionTestPacks(projectionPipelines, reports, reportTestPacks, functionSchemaMap, injector);
+        List<TestPackModel> projectionTestPacks = createProjectionTestPacks(projectionPipelines, reports, reportTestPacks, outputSchemaMap, injector);
         projectionTestPacks.forEach(testPackModel -> testPackConfigWriter.sortAndWriteConfigFile(writePath, PROJECTION_CONFIG_PATH, testPackModel));
     }
 
@@ -259,10 +259,10 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                 .replace("-report", "");
     }
 
-    protected List<TestPackModel> createProjectionTestPacks(List<PipelineModel> projectionPipelines, List<RosettaReport> reports, List<TestPackModel> reportTestPacks, ImmutableMap<Class<?>, String> functionSchemaMap, Injector injector) {
+    protected List<TestPackModel> createProjectionTestPacks(List<PipelineModel> projectionPipelines, List<RosettaReport> reports, List<TestPackModel> reportTestPacks, ImmutableMap<Class<?>, String> outputSchemaMap, Injector injector) {
         return projectionPipelines.stream()
                 .map(p -> {
-                    TestPackFunctionRunner functionRunner = functionRunnerProvider.create(p.getTransform(), p.getOutputSerialisation(), functionSchemaMap, injector);
+                    TestPackFunctionRunner functionRunner = functionRunnerProvider.create(p.getTransform(), p.getOutputSerialisation(), outputSchemaMap, injector);
                     return reportTestPacks.stream()
                             .filter(rtp -> rtp.getPipelineId().equals(p.getUpstreamPipelineId()))
                             .map(upstreamReportTestPack ->

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -33,7 +33,6 @@ import com.rosetta.model.lib.ModelReportId;
 import com.rosetta.model.lib.RosettaModelObject;
 import com.rosetta.model.lib.RosettaModelObjectBuilder;
 import com.rosetta.util.DottedPath;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -333,7 +332,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
         }
     }
 
-    private <OUT extends RosettaModelObject> TestPackModel.SampleModel.@NotNull Assertions processProjectionSchemaValidationFailures(PipelineModel.Transform transform, ImmutableMap<String, String> functionSchemaMap, ObjectWriter objectWriter, OUT output, int actualValidationFailures) throws JsonProcessingException, SAXException {
+    private <OUT extends RosettaModelObject> TestPackModel.SampleModel.Assertions processProjectionSchemaValidationFailures(PipelineModel.Transform transform, ImmutableMap<String, String> functionSchemaMap, ObjectWriter objectWriter, OUT output, int actualValidationFailures) throws JsonProcessingException, SAXException {
         TestPackModel.SampleModel.Assertions assertions;
         //it is projection so we look up the function class, and find the relevant schema
         URL schemaUrl = Resources.getResource(Objects.requireNonNull(functionSchemaMap.get(transform.getFunction())));

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -37,6 +37,7 @@ import static com.regnosys.rosetta.common.transform.TestPackModel.SampleModel;
 import static com.regnosys.rosetta.common.transform.TestPackModel.SampleModel.Assertions;
 import static com.regnosys.rosetta.common.transform.TestPackUtils.*;
 import static com.regnosys.testing.TestingExpectationUtil.TEST_WRITE_BASE_PATH;
+import static com.regnosys.testing.TestingExpectationUtil.writeFile;
 import static com.regnosys.testing.projection.ProjectionPaths.getProjectionDataItemOutputPath;
 
 public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
@@ -240,7 +241,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                     String displayName = baseFileName.replace("-", " ");
 
                     Pair<String, Assertions> result = functionRunner.run(inputPath);
-                    String serialisedOutput = result.left(); // TODO write file
+                    writeOutputFile(outputPath, result.left());
                     Assertions assertions = result.right();
 
                     return new SampleModel(baseFileName.toLowerCase(), displayName, inputPath.toString(), outputPath.toString(), assertions);
@@ -292,7 +293,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
         Path outputPath = getProjectionDataItemOutputPath(projectionTestPackPath, projectionInputPath);
 
         Pair<String, Assertions> result = functionRunner.run(projectionInputPath);
-        String serialisedOutput = result.left(); // TODO write file
+        writeOutputFile(outputPath, result.left());
         Assertions assertions = result.right();
 
         return new SampleModel(reportSample.getId(), reportSample.getName(), projectionInputPath.toString(), outputPath.toString(), assertions);
@@ -303,5 +304,9 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                 .replace(" ", "-")
                 .replace("_", "-")
                 .trim().toLowerCase();
+    }
+
+    private void writeOutputFile(Path outputPath, String serialisedOutput) {
+        writeFile(TEST_WRITE_BASE_PATH.get().resolve(outputPath), serialisedOutput, true);
     }
 }

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -57,7 +57,11 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
      * @param injector          - model runtime guice injector
      */
     @Override
-    public void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths, TestPackFilter filter, List<TestPackDef> testPackDefs, ImmutableMap<Class<?>, String> functionSchemaMap, Injector injector) {
+    public void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths,
+                                                TestPackFilter filter,
+                                                List<TestPackDef> testPackDefs,
+                                                ImmutableMap<Class<?>, String> functionSchemaMap,
+                                                Injector injector) {
         if (TEST_WRITE_BASE_PATH.isEmpty()) {
             LOGGER.error("TEST_WRITE_BASE_PATH not set");
             return;
@@ -234,11 +238,11 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                     Path outputPath = RegReportPaths.getReportExpectationFilePath(outputRelativePath, reportId, testPackName, inputPath);
                     String baseFileName = getBaseFileName(inputPath);
                     String displayName = baseFileName.replace("-", " ");
-                    
+
                     Pair<String, Assertions> result = functionRunner.run(inputPath);
                     String serialisedOutput = result.left(); // TODO write file
                     Assertions assertions = result.right();
-                    
+
                     return new SampleModel(baseFileName.toLowerCase(), displayName, inputPath.toString(), outputPath.toString(), assertions);
                 })
                 .sorted(Comparator.comparing(SampleModel::getId))
@@ -269,7 +273,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                                                     .collect(Collectors.toList()))
                             )
                             .collect(Collectors.toList());
-                        })
+                })
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
     }
@@ -286,11 +290,11 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
         Path projectionInputPath = Path.of(reportSample.getOutputPath());
         Path projectionTestPackPath = RegReportPaths.getOutputDataSetPath(PROJECTION_OUTPUT_PATH, reportId, testPackName);
         Path outputPath = getProjectionDataItemOutputPath(projectionTestPackPath, projectionInputPath);
-        
+
         Pair<String, Assertions> result = functionRunner.run(projectionInputPath);
         String serialisedOutput = result.left(); // TODO write file
         Assertions assertions = result.right();
-        
+
         return new SampleModel(reportSample.getId(), reportSample.getName(), projectionInputPath.toString(), outputPath.toString(), assertions);
     }
 

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -54,7 +54,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
      * @param rosettaPaths      - list of folders that contain rosetta model files, e.g. "drr/rosetta"
      * @param filter            - provides filters to include or exclude
      * @param testPackDefs      - provides list of test-pack information such as test pack name, input type and sample input paths
-     * @param outputSchemaMap - function / xsd look up map
+     * @param outputSchemaMap   - output Document type / xsd look up map
      * @param injector          - model runtime guice injector
      */
     @Override

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -415,9 +415,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
         Path projectionTestPackPath = RegReportPaths.getOutputDataSetPath(PROJECTION_OUTPUT_PATH, reportId, testPackName);
         String outputPath = getProjectionDataItemOutputPath(projectionTestPackPath, Path.of(projectionInputPath)).toString();
         Class<? extends RosettaModelObject> inputType = getClass(pipelineModel.getTransform().getInputType());
-//        Class<? extends RosettaModelObject> outputType = getClass(transform.getOutputType());
         Class<?> functionClass = getClass(pipelineModel.getTransform().getFunction());
-//        return new TestPackModel.SampleModel(reportSample.getId(), reportSample.getName(), projectionInputPath, outputPath, new TestPackModel.SampleModel.Assertions(0, false, false));
         return generateReportTestPackSample(
                 reportSample.getId(),
                 reportSample.getName(),

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
@@ -1,0 +1,11 @@
+package com.regnosys.testing.testpack;
+
+import com.regnosys.rosetta.common.util.Pair;
+
+import java.nio.file.Path;
+
+import static com.regnosys.rosetta.common.transform.TestPackModel.SampleModel.Assertions;
+
+interface TestPackFunctionRunner {
+    Pair<String, Assertions> run(Path inputPath);
+}

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
@@ -56,7 +56,6 @@ class TestPackFunctionRunnerImpl<IN extends RosettaModelObject> implements TestP
     @Override
     public Pair<String, Assertions> run(Path inputPath) {
         URL inputFileUrl = Resources.getResource(inputPath.toString());
-        //assert inputFileUrl != null; // TODO handle nulls (without assert)
         IN input = readFile(inputFileUrl, JSON_OBJECT_MAPPER, inputType);
         RosettaModelObject output;
         try {

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
@@ -1,0 +1,106 @@
+package com.regnosys.testing.testpack;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.io.Resources;
+import com.regnosys.rosetta.common.hashing.ReferenceConfig;
+import com.regnosys.rosetta.common.hashing.ReferenceResolverProcessStep;
+import com.regnosys.rosetta.common.util.Pair;
+import com.regnosys.rosetta.common.validation.RosettaTypeValidator;
+import com.regnosys.rosetta.common.validation.ValidationReport;
+import com.rosetta.model.lib.RosettaModelObject;
+import com.rosetta.model.lib.RosettaModelObjectBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Validator;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.function.Function;
+
+import static com.regnosys.rosetta.common.transform.TestPackModel.SampleModel.Assertions;
+import static com.regnosys.rosetta.common.transform.TestPackUtils.readFile;
+import static com.regnosys.testing.testpack.TestPackFunctionRunnerProviderImpl.JSON_OBJECT_MAPPER;
+
+class TestPackFunctionRunnerImpl<IN extends RosettaModelObject> implements TestPackFunctionRunner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestPackFunctionRunnerImpl.class);
+    
+    private final Function<IN, RosettaModelObject> function;
+    private final Class<IN> inputType;
+    private final RosettaTypeValidator typeValidator;
+    private final ReferenceConfig referenceConfig;
+    private final ObjectWriter outputObjectWriter;
+    private final Validator xsdValidator;
+
+
+    public TestPackFunctionRunnerImpl(Function<IN, RosettaModelObject> function,
+                                      Class<IN> inputType,
+                                      RosettaTypeValidator typeValidator,
+                                      ReferenceConfig referenceConfig,
+                                      ObjectWriter outputObjectWriter,
+                                      Validator xsdValidator) {
+        this.function = function;
+        this.inputType = inputType;
+        this.typeValidator = typeValidator;
+        this.referenceConfig = referenceConfig;
+        this.outputObjectWriter = outputObjectWriter;
+        this.xsdValidator = xsdValidator;
+    }
+
+    @Override
+    public Pair<String, Assertions> run(Path inputPath) {
+        URL inputFileUrl = Resources.getResource(inputPath.toString());
+        //assert inputFileUrl != null; // TODO handle nulls (without assert)
+        IN input = readFile(inputFileUrl, JSON_OBJECT_MAPPER, inputType);
+        RosettaModelObject output;
+        try {
+            output = function.apply(resolveReferences(input));
+        } catch (Exception e) {
+            LOGGER.error("Exception occurred running sample creation", e);
+            return Pair.of(null, new Assertions(null, null, true));
+        }
+
+        String serialisedOutput;
+        try {
+            serialisedOutput = outputObjectWriter.writeValueAsString(output);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialise function output", e);
+        }
+
+        ValidationReport validationReport = typeValidator.runProcessStep(output.getType(), output);
+        validationReport.logReport();
+        int actualValidationFailures = validationReport.validationFailures().size();
+
+        Boolean schemaValidationFailure = isSchemaValidationFailure(serialisedOutput);
+        
+        Assertions assertions = new Assertions(actualValidationFailures, schemaValidationFailure, false);
+        return Pair.of(serialisedOutput, assertions);
+    }
+    
+    private <T extends RosettaModelObject> T resolveReferences(T o) {
+        RosettaModelObjectBuilder builder = o.toBuilder();
+        new ReferenceResolverProcessStep(referenceConfig).runProcessStep(o.getType(), builder);
+        return (T) builder.build();
+    }
+
+    private Boolean isSchemaValidationFailure(String xml) {
+        if (xsdValidator == null) {
+            return null;
+        }
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            xsdValidator.validate(new StreamSource(inputStream));
+            return true;
+        } catch (SAXException e) {
+            LOGGER.error("Schema validation failed: {}", e.getMessage());
+            return false;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProvider.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProvider.java
@@ -1,0 +1,16 @@
+package com.regnosys.testing.testpack;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.ImplementedBy;
+import com.google.inject.Injector;
+
+import static com.regnosys.rosetta.common.transform.PipelineModel.Serialisation;
+import static com.regnosys.rosetta.common.transform.PipelineModel.Transform;
+
+@ImplementedBy(TestPackFunctionRunnerProviderImpl.class)
+public interface TestPackFunctionRunnerProvider {
+    
+    TestPackFunctionRunner create(Transform transform, Injector injector);
+
+    TestPackFunctionRunner create(Transform transform, Serialisation outputSerialisation, ImmutableMap<Class<?>, String> functionSchemaMap, Injector injector);
+}

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProvider.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProvider.java
@@ -12,5 +12,5 @@ public interface TestPackFunctionRunnerProvider {
     
     TestPackFunctionRunner create(Transform transform, Injector injector);
 
-    TestPackFunctionRunner create(Transform transform, Serialisation outputSerialisation, ImmutableMap<Class<?>, String> functionSchemaMap, Injector injector);
+    TestPackFunctionRunner create(Transform transform, Serialisation outputSerialisation, ImmutableMap<Class<?>, String> outputSchemaMap, Injector injector);
 }

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
@@ -49,7 +49,7 @@ class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvid
     @Override
     public TestPackFunctionRunner create(PipelineModel.Transform transform, PipelineModel.Serialisation outputSerialisation, ImmutableMap<Class<?>, String> functionSchemaMap, Injector injector) {
         Class<? extends RosettaModelObject> inputType = toClass(transform.getInputType());
-        Class<?> functionType = toClass(transform.getFunction());
+        Class<?> functionType = toClass(transform.getOutputType());
         // Output serialisation
         ObjectWriter outputObjectWriter = getObjectWriter(outputSerialisation).orElse(JSON_OBJECT_WRITER);
         // XSD validation

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
@@ -87,8 +87,8 @@ class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvid
         };
     }
 
-    private Validator getXsdValidator(Class<?> functionType, ImmutableMap<Class<?>, String> functionSchemaMap) {
-        URL schemaUrl = Optional.ofNullable(functionSchemaMap.get(functionType))
+    private Validator getXsdValidator(Class<?> functionType, ImmutableMap<Class<?>, String> outputSchemaMap) {
+        URL schemaUrl = Optional.ofNullable(outputSchemaMap.get(functionType))
                 .map(r -> Resources.getResource(r))
                 .orElse(null);
         if (schemaUrl == null) {

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
@@ -1,0 +1,107 @@
+package com.regnosys.testing.testpack;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.google.inject.Injector;
+import com.regnosys.rosetta.common.hashing.ReferenceConfig;
+import com.regnosys.rosetta.common.serialisation.RosettaObjectMapper;
+import com.regnosys.rosetta.common.transform.PipelineModel;
+import com.regnosys.rosetta.common.validation.RosettaTypeValidator;
+import com.rosetta.model.lib.RosettaModelObject;
+import org.xml.sax.SAXException;
+
+import javax.inject.Inject;
+import javax.xml.XMLConstants;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.regnosys.rosetta.common.transform.TestPackUtils.getObjectWriter;
+
+class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvider {
+
+    protected static final ObjectMapper JSON_OBJECT_MAPPER = RosettaObjectMapper.getNewRosettaObjectMapper();
+    protected final static ObjectWriter JSON_OBJECT_WRITER =
+            JSON_OBJECT_MAPPER
+                    .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                    .writerWithDefaultPrettyPrinter();
+    
+    @Inject
+    RosettaTypeValidator typeValidator;
+    @Inject
+    ReferenceConfig referenceConfig;
+
+    @Override
+    public TestPackFunctionRunner create(PipelineModel.Transform transform, Injector injector) {
+        Class<? extends RosettaModelObject> inputType = toClass(transform.getInputType());
+        Class<?> functionType = toClass(transform.getFunction());
+        return createTestPackFunctionRunner(functionType, inputType, injector, JSON_OBJECT_WRITER, null);
+    }
+
+    @Override
+    public TestPackFunctionRunner create(PipelineModel.Transform transform, PipelineModel.Serialisation outputSerialisation, ImmutableMap<Class<?>, String> functionSchemaMap, Injector injector) {
+        Class<? extends RosettaModelObject> inputType = toClass(transform.getInputType());
+        Class<?> functionType = toClass(transform.getFunction());
+        // Output serialisation
+        ObjectWriter outputObjectWriter = getObjectWriter(outputSerialisation).orElse(JSON_OBJECT_WRITER);
+        // XSD validation
+        Validator xsdValidator = getXsdValidator(functionType, functionSchemaMap);
+        return createTestPackFunctionRunner(functionType, inputType, injector, outputObjectWriter, xsdValidator);
+    }
+    
+    private <IN extends RosettaModelObject> TestPackFunctionRunner createTestPackFunctionRunner(Class<?> functionType, Class<IN> inputType, Injector injector, ObjectWriter outputObjectWriter, Validator xsdValidator) {
+        Function<IN, RosettaModelObject> transformFunction = getTransformFunction(functionType, inputType, injector);
+        return new TestPackFunctionRunnerImpl<>(transformFunction, inputType, typeValidator, referenceConfig, outputObjectWriter, xsdValidator);
+    }
+
+    private Class<? extends RosettaModelObject> toClass(String name) {
+        try {
+            return (Class<? extends RosettaModelObject>) Class.forName(name);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <IN extends RosettaModelObject> Function<IN, RosettaModelObject> getTransformFunction(Class<?> functionType, Class<IN> inputType, Injector injector) {
+        Object functionInstance = injector.getInstance(functionType);
+        Method evaluateMethod;
+        try {
+            evaluateMethod = functionInstance.getClass().getMethod("evaluate", inputType);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(String.format("Evaluate method with input type %s not found", inputType.getName()), e);
+        }
+        return (resolvedInput) -> {
+            try {
+                return (RosettaModelObject) evaluateMethod.invoke(functionInstance, resolvedInput);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException("Failed to invoke evaluate method", e);
+            }
+        };
+    }
+
+    private Validator getXsdValidator(Class<?> functionType, ImmutableMap<Class<?>, String> functionSchemaMap) {
+        URL schemaUrl = Optional.ofNullable(functionSchemaMap.get(functionType))
+                .map(r -> Resources.getResource(r))
+                .orElse(null);
+        if (schemaUrl == null) {
+            return null;
+        }
+        try {
+            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            // required to process xml elements with an maxOccurs greater than 5000 (rather than unbounded)
+            schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);
+            Schema schema = schemaFactory.newSchema(schemaUrl);
+            return schema.newValidator();
+        } catch (SAXException e) {
+            throw new RuntimeException(String.format("Failed to create schema validator for {}", schemaUrl),e);
+        }
+    }
+}

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
@@ -47,18 +47,18 @@ class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvid
     }
 
     @Override
-    public TestPackFunctionRunner create(PipelineModel.Transform transform, PipelineModel.Serialisation outputSerialisation, ImmutableMap<Class<?>, String> functionSchemaMap, Injector injector) {
+    public TestPackFunctionRunner create(PipelineModel.Transform transform, PipelineModel.Serialisation outputSerialisation, ImmutableMap<Class<?>, String> outputSchemaMap, Injector injector) {
         Class<? extends RosettaModelObject> inputType = toClass(transform.getInputType());
-        Class<?> functionType = toClass(transform.getOutputType());
+        Class<?> outputType = toClass(transform.getOutputType());
         // Output serialisation
         ObjectWriter outputObjectWriter = getObjectWriter(outputSerialisation).orElse(JSON_OBJECT_WRITER);
         // XSD validation
-        Validator xsdValidator = getXsdValidator(functionType, functionSchemaMap);
-        return createTestPackFunctionRunner(functionType, inputType, injector, outputObjectWriter, xsdValidator);
+        Validator xsdValidator = getXsdValidator(outputType, outputSchemaMap);
+        return createTestPackFunctionRunner(outputType, inputType, injector, outputObjectWriter, xsdValidator);
     }
-    
-    private <IN extends RosettaModelObject> TestPackFunctionRunner createTestPackFunctionRunner(Class<?> functionType, Class<IN> inputType, Injector injector, ObjectWriter outputObjectWriter, Validator xsdValidator) {
-        Function<IN, RosettaModelObject> transformFunction = getTransformFunction(functionType, inputType, injector);
+
+    private <IN extends RosettaModelObject> TestPackFunctionRunner createTestPackFunctionRunner(Class<?> outputType, Class<IN> inputType, Injector injector, ObjectWriter outputObjectWriter, Validator xsdValidator) {
+        Function<IN, RosettaModelObject> transformFunction = getTransformFunction(outputType, inputType, injector);
         return new TestPackFunctionRunnerImpl<>(transformFunction, inputType, typeValidator, referenceConfig, outputObjectWriter, xsdValidator);
     }
 


### PR DESCRIPTION
## Description:

This change covers test pack generation, creating test packs with the corrected test pack JSON files and the correct values of model validation Errors and schema validation failure values.