### PR TITLE
task-4578: fixed issue where Document class is not found

### DIFF
--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.testpack;
 
+/*-
+ * ===============
+ * Rosetta Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.regnosys.rosetta.common.util.Pair;
 
 import java.nio.file.Path;

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.testpack;
 
+/*-
+ * ===============
+ * Rosetta Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.io.Resources;

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProvider.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProvider.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.testpack;
 
+/*-
+ * ===============
+ * Rosetta Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.ImplementedBy;
 import com.google.inject.Injector;

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
@@ -1,5 +1,25 @@
 package com.regnosys.testing.testpack;
 
+/*-
+ * ===============
+ * Rosetta Testing
+ * ===============
+ * Copyright (C) 2022 - 2024 REGnosys
+ * ===============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===============
+ */
+
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -54,11 +74,11 @@ class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvid
         ObjectWriter outputObjectWriter = getObjectWriter(outputSerialisation).orElse(JSON_OBJECT_WRITER);
         // XSD validation
         Validator xsdValidator = getXsdValidator(outputType, outputSchemaMap);
-        return createTestPackFunctionRunner(outputType, inputType, injector, outputObjectWriter, xsdValidator);
+        return createTestPackFunctionRunner(toClass(transform.getFunction()), inputType, injector, outputObjectWriter, xsdValidator);
     }
 
-    private <IN extends RosettaModelObject> TestPackFunctionRunner createTestPackFunctionRunner(Class<?> outputType, Class<IN> inputType, Injector injector, ObjectWriter outputObjectWriter, Validator xsdValidator) {
-        Function<IN, RosettaModelObject> transformFunction = getTransformFunction(outputType, inputType, injector);
+    private <IN extends RosettaModelObject> TestPackFunctionRunner createTestPackFunctionRunner(Class<?> function, Class<IN> inputType, Injector injector, ObjectWriter outputObjectWriter, Validator xsdValidator) {
+        Function<IN, RosettaModelObject> transformFunction = getTransformFunction(function, inputType, injector);
         return new TestPackFunctionRunnerImpl<>(transformFunction, inputType, typeValidator, referenceConfig, outputObjectWriter, xsdValidator);
     }
 

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerProviderImpl.java
@@ -9,9 +9,9 @@ package com.regnosys.testing.testpack;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,7 +53,7 @@ class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvid
             JSON_OBJECT_MAPPER
                     .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
                     .writerWithDefaultPrettyPrinter();
-    
+
     @Inject
     RosettaTypeValidator typeValidator;
     @Inject
@@ -77,8 +77,8 @@ class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvid
         return createTestPackFunctionRunner(toClass(transform.getFunction()), inputType, injector, outputObjectWriter, xsdValidator);
     }
 
-    private <IN extends RosettaModelObject> TestPackFunctionRunner createTestPackFunctionRunner(Class<?> function, Class<IN> inputType, Injector injector, ObjectWriter outputObjectWriter, Validator xsdValidator) {
-        Function<IN, RosettaModelObject> transformFunction = getTransformFunction(function, inputType, injector);
+    private <IN extends RosettaModelObject> TestPackFunctionRunner createTestPackFunctionRunner(Class<?> functionType, Class<IN> inputType, Injector injector, ObjectWriter outputObjectWriter, Validator xsdValidator) {
+        Function<IN, RosettaModelObject> transformFunction = getTransformFunction(functionType, inputType, injector);
         return new TestPackFunctionRunnerImpl<>(transformFunction, inputType, typeValidator, referenceConfig, outputObjectWriter, xsdValidator);
     }
 
@@ -121,7 +121,7 @@ class TestPackFunctionRunnerProviderImpl implements TestPackFunctionRunnerProvid
             Schema schema = schemaFactory.newSchema(schemaUrl);
             return schema.newValidator();
         } catch (SAXException e) {
-            throw new RuntimeException(String.format("Failed to create schema validator for {}", schemaUrl),e);
+            throw new RuntimeException(String.format("Failed to create schema validator for {}", schemaUrl), e);
         }
     }
 }


### PR DESCRIPTION
Story-880: A Model Maintainer Can Run The Test Pack Configurator And Correct Assertions
Description:
Bundle 11.7.5 released A change to the `TestPackConfigCreatorImpl` class, changing how test packs and pipeline files were created; test packs would now have the correct initial values provided to them, rather than zeroed-out values.

Issue:
There is an issue where the function schema maps provided by DRR and client models provide their relevant Rosetta Document classes. These are fine for getting the correct schema file, but they do not hold the function evaluate function that is needed for correct output serialisation. As they are injected, a Guice exception occurs because there is no implementation that can be used to apply the relevant function.

Fix:
Schema map stays the same and is used for xsd validation, but the `createTestPackFunctionRunner()` Method takes the class of the function not the output type instead. 