### PR TITLE
Story-898 Task-4684: Addressed issue where generated input classes are being used as Input Path

### DIFF
--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -9,9 +9,9 @@ package com.regnosys.testing.testpack;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -72,11 +71,11 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
     /**
      * Generates pipeline and test-pack config files.
      *
-     * @param rosettaPaths      - list of folders that contain rosetta model files, e.g. "drr/rosetta"
-     * @param filter            - provides filters to include or exclude
-     * @param testPackDefs      - provides list of test-pack information such as test pack name, input type and sample input paths
-     * @param outputSchemaMap   - output Document type / xsd look up map
-     * @param injector          - model runtime guice injector
+     * @param rosettaPaths    - list of folders that contain rosetta model files, e.g. "drr/rosetta"
+     * @param filter          - provides filters to include or exclude
+     * @param testPackDefs    - provides list of test-pack information such as test pack name, input type and sample input paths
+     * @param outputSchemaMap - output Document type / xsd look up map
+     * @param injector        - model runtime guice injector
      */
     @Override
     public void createPipelineAndTestPackConfig(ImmutableList<String> rosettaPaths,
@@ -262,11 +261,8 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                     String displayName = baseFileName.replace("-", " ");
 
                     Pair<String, Assertions> result = null;
-                    try {
-                        result = functionRunner.run(inputPath);
-                    } catch (UncheckedIOException e) {
-                        throw new RuntimeException("Unable to apply report function. Invalid input path", e);
-                    }
+                    result = functionRunner.run(inputPath);
+
                     writeOutputFile(outputPath, result.left());
                     Assertions assertions = result.right();
 
@@ -296,13 +292,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                                             TransformType.PROJECTION,
                                             createIdSuffix(p.getTransform().getFunction()),
                                             upstreamReportTestPack.getSamples().stream()
-                                                    .map(s -> {
-                                                        try {
-                                                            return toProjectionSample(upstreamReportTestPack.getName(), getModelReportId(reports, upstreamReportTestPack.getPipelineId()), s, functionRunner);
-                                                        } catch (UncheckedIOException e) {
-                                                            throw new RuntimeException("Unable to apply projection function. Invalid input path", e);
-                                                        }
-                                                    })
+                                                    .map(s -> toProjectionSample(upstreamReportTestPack.getName(), getModelReportId(reports, upstreamReportTestPack.getPipelineId()), s, functionRunner))
                                                     .collect(Collectors.toList()))
                             )
                             .collect(Collectors.toList());

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -260,8 +260,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                     String baseFileName = getBaseFileName(inputPath);
                     String displayName = baseFileName.replace("-", " ");
 
-                    Pair<String, Assertions> result = null;
-                    result = functionRunner.run(inputPath);
+                    Pair<String, Assertions> result = functionRunner.run(inputPath);
 
                     writeOutputFile(outputPath, result.left());
                     Assertions assertions = result.right();

--- a/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackConfigCreatorImpl.java
@@ -46,7 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.net.MalformedURLException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -264,7 +264,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                     Pair<String, Assertions> result = null;
                     try {
                         result = functionRunner.run(inputPath);
-                    } catch (MalformedURLException e) {
+                    } catch (UncheckedIOException e) {
                         throw new RuntimeException("Unable to apply report function. Invalid input path", e);
                     }
                     writeOutputFile(outputPath, result.left());
@@ -299,7 +299,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                                                     .map(s -> {
                                                         try {
                                                             return toProjectionSample(upstreamReportTestPack.getName(), getModelReportId(reports, upstreamReportTestPack.getPipelineId()), s, functionRunner);
-                                                        } catch (MalformedURLException e) {
+                                                        } catch (UncheckedIOException e) {
                                                             throw new RuntimeException("Unable to apply projection function. Invalid input path", e);
                                                         }
                                                     })
@@ -319,7 +319,7 @@ public class TestPackConfigCreatorImpl implements TestPackConfigCreator {
                 .orElseThrow();
     }
 
-    protected SampleModel toProjectionSample(String testPackName, ModelReportId reportId, SampleModel reportSample, TestPackFunctionRunner functionRunner) throws MalformedURLException {
+    protected SampleModel toProjectionSample(String testPackName, ModelReportId reportId, SampleModel reportSample, TestPackFunctionRunner functionRunner) {
         Path projectionInputPath = Path.of(reportSample.getOutputPath());
         Path projectionTestPackPath = RegReportPaths.getOutputDataSetPath(PROJECTION_OUTPUT_PATH, reportId, testPackName);
         Path outputPath = getProjectionDataItemOutputPath(projectionTestPackPath, projectionInputPath);

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
@@ -22,10 +22,11 @@ package com.regnosys.testing.testpack;
 
 import com.regnosys.rosetta.common.util.Pair;
 
+import java.net.MalformedURLException;
 import java.nio.file.Path;
 
 import static com.regnosys.rosetta.common.transform.TestPackModel.SampleModel.Assertions;
 
 interface TestPackFunctionRunner {
-    Pair<String, Assertions> run(Path inputPath);
+    Pair<String, Assertions> run(Path inputPath) throws MalformedURLException;
 }

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunner.java
@@ -22,11 +22,10 @@ package com.regnosys.testing.testpack;
 
 import com.regnosys.rosetta.common.util.Pair;
 
-import java.net.MalformedURLException;
 import java.nio.file.Path;
 
 import static com.regnosys.rosetta.common.transform.TestPackModel.SampleModel.Assertions;
 
 interface TestPackFunctionRunner {
-    Pair<String, Assertions> run(Path inputPath) throws MalformedURLException;
+    Pair<String, Assertions> run(Path inputPath);
 }

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
@@ -22,7 +22,6 @@ package com.regnosys.testing.testpack;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.io.Resources;
 import com.regnosys.rosetta.common.hashing.ReferenceConfig;
 import com.regnosys.rosetta.common.hashing.ReferenceResolverProcessStep;
 import com.regnosys.rosetta.common.util.Pair;
@@ -39,6 +38,7 @@ import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -50,7 +50,8 @@ import static com.regnosys.testing.testpack.TestPackFunctionRunnerProviderImpl.J
 
 class TestPackFunctionRunnerImpl<IN extends RosettaModelObject> implements TestPackFunctionRunner {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestPackFunctionRunnerImpl.class);
-    
+    public static final Path ROSETTA_SOURCE_PATH = Path.of("rosetta-source/src/main/resources/");
+
     private final Function<IN, RosettaModelObject> function;
     private final Class<IN> inputType;
     private final RosettaTypeValidator typeValidator;
@@ -74,8 +75,9 @@ class TestPackFunctionRunnerImpl<IN extends RosettaModelObject> implements TestP
     }
 
     @Override
-    public Pair<String, Assertions> run(Path inputPath) {
-        URL inputFileUrl = Resources.getResource(inputPath.toString());
+    public Pair<String, Assertions> run(Path inputPath) throws MalformedURLException {
+        inputPath = ROSETTA_SOURCE_PATH.resolve(inputPath);
+        URL inputFileUrl = inputPath.toUri().toURL();
         IN input = readFile(inputFileUrl, JSON_OBJECT_MAPPER, inputType);
         RosettaModelObject output;
         try {

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
@@ -38,7 +38,6 @@ import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -82,8 +81,6 @@ class TestPackFunctionRunnerImpl<IN extends RosettaModelObject> implements TestP
             URL inputFileUrl = inputPathFromRepositoryRoot.toUri().toURL();
             IN input = readFile(inputFileUrl, JSON_OBJECT_MAPPER, inputType);
             output = function.apply(resolveReferences(input));
-        } catch (MalformedURLException e) {
-            throw new UncheckedIOException("Unable to read input path", e);
         } catch (Exception e) {
             LOGGER.error("Exception occurred running sample creation", e);
             return Pair.of(null, new Assertions(null, null, true));

--- a/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
+++ b/src/main/java/com/regnosys/testing/testpack/TestPackFunctionRunnerImpl.java
@@ -38,6 +38,7 @@ import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -81,6 +82,9 @@ class TestPackFunctionRunnerImpl<IN extends RosettaModelObject> implements TestP
             URL inputFileUrl = inputPathFromRepositoryRoot.toUri().toURL();
             IN input = readFile(inputFileUrl, JSON_OBJECT_MAPPER, inputType);
             output = function.apply(resolveReferences(input));
+        } catch (MalformedURLException e) {
+            LOGGER.error("Failed to load input path {}", inputPath, e);
+            return Pair.of(null, new Assertions(null, null, true));
         } catch (Exception e) {
             LOGGER.error("Exception occurred running sample creation", e);
             return Pair.of(null, new Assertions(null, null, true));


### PR DESCRIPTION
Please include a summary of the change and the issue/story number.
STORY-898
This change makes sure we are using the actual path of Rosetta-source. Previously we were erroneously using the generated path. which would use the previously generated rosetta-source and so would require re-runs to regenerate and use an up to date folder.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
